### PR TITLE
ci: update lock file with floxbot

### DIFF
--- a/.github/workflows/trigger-floxpkgs-internal-update.yml
+++ b/.github/workflows/trigger-floxpkgs-internal-update.yml
@@ -2,6 +2,8 @@ name: "Trigger Update of floxpkgs internal"
 
 on:
   push:
+    branches:
+      - "master"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger-floxpkgs-update.yml
+++ b/.github/workflows/trigger-floxpkgs-update.yml
@@ -2,6 +2,8 @@ name: "Trigger Update of floxpkgs"
 
 on:
   push:
+    branches:
+      - "master"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-lock-file.yml
+++ b/.github/workflows/update-lock-file.yml
@@ -1,12 +1,6 @@
 name: "Update Lock File"
 
 on:
-  push:
-    branches:
-      - "stable"
-      - "staging"
-      - "unstable"
-      - "master"
   workflow_dispatch:
 
 concurrency:
@@ -25,6 +19,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: master
+          # Pushes made by the action token do not trigger additional actions
+          token: secrets.NIX_GIT_TOKEN
       - name: "Install nix"
         uses: cachix/install-nix-action@v17
         with:


### PR DESCRIPTION
Catalog progressions trigger updates of the flake.lock file through the `update-lock-file` action. Yet, since the action uses the github supplied token, its pushes do not  invoke the floxpkgs update triggers.

This commit will
a) make the `update-lock-file` action purely work on workflow dispatches (i.e. when triggered by a catalog progression)
b) use the floxbot token to push the updated lockfile to ensure floxpkgs triggers are run
c) restrict floxpkgs updates to changes on `master`